### PR TITLE
Add GitHub link button

### DIFF
--- a/zip-extractor-astro/src/components/GitHubLink.tsx
+++ b/zip-extractor-astro/src/components/GitHubLink.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Button } from "@/components/ui/button";
-import { GitHub } from "lucide-react";
+import { Github } from "lucide-react";
 
 interface GitHubLinkProps {
   repo: string;
@@ -9,15 +9,17 @@ interface GitHubLinkProps {
 export function GitHubLink({ repo }: GitHubLinkProps) {
   return (
     <Button
-      as="a"
+      asChild
       href={`https://github.com/${repo}`}
       target="_blank"
       rel="noopener noreferrer"
       variant="outline"
       size="icon"
     >
-      <GitHub className="h-[1.2rem] w-[1.2rem]" />
-      <span className="sr-only">GitHub Repository</span>
+      <a>
+        <Github className="h-[1.2rem] w-[1.2rem]" />
+        <span className="sr-only">GitHub Repository</span>
+      </a>
     </Button>
   );
 }

--- a/zip-extractor-astro/src/components/GitHubLink.tsx
+++ b/zip-extractor-astro/src/components/GitHubLink.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import { GitHub } from "lucide-react";
+
+interface GitHubLinkProps {
+  repo: string;
+}
+
+export function GitHubLink({ repo }: GitHubLinkProps) {
+  return (
+    <Button
+      as="a"
+      href={`https://github.com/${repo}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      variant="outline"
+      size="icon"
+    >
+      <GitHub className="h-[1.2rem] w-[1.2rem]" />
+      <span className="sr-only">GitHub Repository</span>
+    </Button>
+  );
+}

--- a/zip-extractor-astro/src/components/GitHubLink.tsx
+++ b/zip-extractor-astro/src/components/GitHubLink.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { Button } from "@/components/ui/button";
 import { Github } from "lucide-react";
+import { buttonVariants } from "@/components/ui/button"
+
 
 interface GitHubLinkProps {
   repo: string;
@@ -8,15 +10,8 @@ interface GitHubLinkProps {
 
 export function GitHubLink({ repo }: GitHubLinkProps) {
   return (
-    <Button
-      asChild
-      href={`https://github.com/${repo}`}
-      target="_blank"
-      rel="noopener noreferrer"
-      variant="outline"
-      size="icon"
-    >
-      <a>
+    <Button asChild variant="outline" size="icon">
+      <a href={`https://github.com/${repo}`} target="_blank" rel="noopener noreferrer">
         <Github className="h-[1.2rem] w-[1.2rem]" />
         <span className="sr-only">GitHub Repository</span>
       </a>

--- a/zip-extractor-astro/src/pages/index.astro
+++ b/zip-extractor-astro/src/pages/index.astro
@@ -2,6 +2,7 @@
 import '@/styles/globals.css'
 import { ZipExtractor } from '@/components/ZipExtractor/ZipExtractor'
 import { ModeToggle } from '@/components/ModeToggle'
+import { GitHubLink } from '@/components/GitHubLink'
 ---
 
 <script is:inline>
@@ -34,8 +35,9 @@ import { ModeToggle } from '@/components/ModeToggle'
 	</head>
 	<body>
 		<main class="min-h-screen bg-background">
-			<div class="absolute top-4 right-4">
+			<div class="absolute top-4 right-4 flex items-center space-x-2">
 				<ModeToggle client:load />
+				<GitHubLink repo="gtg922r/zip-extractor" client:load />
 			</div>
 			<ZipExtractor client:load />
 		</main>

--- a/zip-extractor-astro/src/pages/index.astro
+++ b/zip-extractor-astro/src/pages/index.astro
@@ -35,7 +35,7 @@ import { GitHubLink } from '@/components/GitHubLink'
 	</head>
 	<body>
 		<main class="min-h-screen bg-background">
-			<div class="absolute top-4 right-4 flex items-center space-x-2">
+			<div class="absolute top-4 right-4 flex items-center space-x-2 gap-2">
 				<ModeToggle client:load />
 				<GitHubLink repo="gtg922r/zip-extractor" client:load />
 			</div>


### PR DESCRIPTION
Fixes #1

- Adds a new githublink component which links to the projects github repo

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gtg922r/zip-extractor/pull/2?shareId=aea635d1-f014-4579-9a59-82e3f89472e7).